### PR TITLE
Feature/Add Attribute Filters

### DIFF
--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -37,7 +37,8 @@ module ScimRails
       :user_attributes,
       :user_deprovision_method,
       :user_reprovision_method,
-      :user_schema
+      :user_schema,
+      :user_attribute_filters
 
     def initialize
       @basic_auth_model = 'Company'

--- a/spec/controllers/scim_rails/scim_users_controller_create_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_create_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(user.email).to eq 'new@example.com'
       end
 
+      it 'filters through an attribute if specified' do
+        allow(ScimRails.config).to(
+          receive(:user_attribute_filters)
+          .and_return({ email: :downcase })
+        )
+        expect(company.users.count).to eq 0
+
+        post :create, params: {
+          name: {
+            givenName: 'New',
+            familyName: 'User'
+          },
+          emails: [
+            {
+              value: 'NeW@example.com'
+            }
+          ]
+        }, as: :json
+
+        user = company.users.first
+        expect(user.email).to eq 'new@example.com'
+      end
+
       it 'ignores unconfigured params' do
         post :create, params: {
           name: {

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -115,6 +115,40 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(response_body['Resources'].count).to eq 1
       end
 
+      it 'applies filters on attributes if specified' do
+        allow(ScimRails.config).to(
+          receive(:user_attribute_filters)
+          .and_return({ email: :downcase })
+        )
+
+        create(:user, email: 'test1@example.com', company: company)
+        create(:user, email: 'test2@example.com', company: company)
+
+        get :index, params: {
+          filter: 'email eq TeSt1@example.com'
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body['totalResults']).to eq 1
+        expect(response_body['Resources'].count).to eq 1
+      end
+
+      it 'applies filters on attributes if specified (callback)' do
+        allow(ScimRails.config).to(
+          receive(:user_attribute_filters)
+          .and_return({ email: ->(email) { email.downcase } })
+        )
+
+        create(:user, email: 'test1@example.com', company: company)
+        create(:user, email: 'test2@example.com', company: company)
+
+        get :index, params: {
+          filter: 'email eq TeSt1@example.com'
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body['totalResults']).to eq 1
+        expect(response_body['Resources'].count).to eq 1
+      end
+
       it 'filters results by provided name filter' do
         create(:user, first_name: 'Chidi', last_name: 'Anagonye',
                       company: company

--- a/spec/dummy/config/initializers/scim_rails_config.rb
+++ b/spec/dummy/config/initializers/scim_rails_config.rb
@@ -50,4 +50,6 @@ ScimRails.configure do |config|
     ],
     active: :unarchived?
   }
+
+  config.user_attribute_filters = {}
 end


### PR DESCRIPTION
This PR allows to set up a configuration object to define filters
to pass attributes through.

This may be desired if the attributes being sent from the provider
are not consistent.  For example, Azure capitalises the names and
surnames in emails, and we want to be able to lowercase this.
(Check the tests for this PR for an example of how to achieve this).

